### PR TITLE
Add French color picker locale

### DIFF
--- a/locale/fr-fr/dialog/color-not-found.dialog
+++ b/locale/fr-fr/dialog/color-not-found.dialog
@@ -1,0 +1,1 @@
+Je n'ai pas trouvé cette couleur.

--- a/locale/fr-fr/dialog/report-color-by-hex-name-known.dialog
+++ b/locale/fr-fr/dialog/report-color-by-hex-name-known.dialog
@@ -1,0 +1,1 @@
+C'est {color_name}. Ses valeurs RVB sont : rouge {red_value}, vert {green_value}, bleu {blue_value}.

--- a/locale/fr-fr/dialog/report-color-by-hex-name-not-known.dialog
+++ b/locale/fr-fr/dialog/report-color-by-hex-name-not-known.dialog
@@ -1,0 +1,1 @@
+Les valeurs RVB de cette couleur sont : rouge {red_value}, vert {green_value}, bleu {blue_value}.

--- a/locale/fr-fr/dialog/report-color-by-name.dialog
+++ b/locale/fr-fr/dialog/report-color-by-name.dialog
@@ -1,0 +1,1 @@
+{color_name} a pour code hexadécimal {hex_code}. En RVB, cela donne rouge {red_value}, vert {green_value}, bleu {blue_value}.

--- a/locale/fr-fr/dialog/report-color-by-rgb-name-known.dialog
+++ b/locale/fr-fr/dialog/report-color-by-rgb-name-known.dialog
@@ -1,0 +1,1 @@
+{color_name} a pour code hexadécimal {hex_code}.

--- a/locale/fr-fr/dialog/report-color-by-rgb-name-not-known.dialog
+++ b/locale/fr-fr/dialog/report-color-by-rgb-name-not-known.dialog
@@ -1,0 +1,1 @@
+Cette couleur a pour code hexadécimal {hex_code}.

--- a/locale/fr-fr/intents/request-color-by-hex.intent
+++ b/locale/fr-fr/intents/request-color-by-hex.intent
@@ -1,0 +1,1 @@
+quelle couleur a un code hexadécimal {hex_code}

--- a/locale/fr-fr/intents/request-color-by-name.intent
+++ b/locale/fr-fr/intents/request-color-by-name.intent
@@ -1,0 +1,2 @@
+montre-moi la couleur {color}
+à quoi ressemble la couleur {color}

--- a/locale/fr-fr/intents/request-color-by-rgb.intent
+++ b/locale/fr-fr/intents/request-color-by-rgb.intent
@@ -1,0 +1,1 @@
+quelle couleur a une valeur RVB de {rgb}

--- a/locale/fr-fr/intents/request-color.intent
+++ b/locale/fr-fr/intents/request-color.intent
@@ -1,0 +1,1 @@
+de quelle couleur est {requested_color}

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,5 @@
+{
+  "examples": [
+    "montre-moi la couleur verte"
+  ]
+}

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,0 +1,20 @@
+{
+  "/dialog/report-color-by-rgb-name-not-known.dialog": [
+    "Cette couleur a pour code hexadécimal {hex_code}."
+  ],
+  "/dialog/color-not-found.dialog": [
+    "Je n'ai pas trouvé cette couleur."
+  ],
+  "/dialog/report-color-by-rgb-name-known.dialog": [
+    "{color_name} a pour code hexadécimal {hex_code}."
+  ],
+  "/dialog/report-color-by-hex-name-not-known.dialog": [
+    "Les valeurs RVB de cette couleur sont : rouge {red_value}, vert {green_value}, bleu {blue_value}."
+  ],
+  "/dialog/report-color-by-hex-name-known.dialog": [
+    "C'est {color_name}. Ses valeurs RVB sont : rouge {red_value}, vert {green_value}, bleu {blue_value}."
+  ],
+  "/dialog/report-color-by-name.dialog": [
+    "{color_name} a pour code hexadécimal {hex_code}. En RVB, cela donne rouge {red_value}, vert {green_value}, bleu {blue_value}."
+  ]
+}

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,0 +1,15 @@
+{
+  "/intents/request-color-by-name.intent": [
+    "montre-moi la couleur {color}",
+    "à quoi ressemble la couleur {color}"
+  ],
+  "/intents/request-color-by-rgb.intent": [
+    "quelle couleur a une valeur RVB de {rgb}"
+  ],
+  "/intents/request-color.intent": [
+    "de quelle couleur est {requested_color}"
+  ],
+  "/intents/request-color-by-hex.intent": [
+    "quelle couleur a un code hexadécimal {hex_code}"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a complete French locale for the color picker skill, including intents, dialogs, examples, and translation snapshots.

## Validation
- locale coverage compared against the English source locale
- JSON translation files parse cleanly
- git diff --check
