### PR TITLE
feat: complete da-DK translation

### DIFF
--- a/locale/da-DK/color.blacklist
+++ b/locale/da-DK/color.blacklist
@@ -1,0 +1,14 @@
+# Slot-value exclusion for the {color} slot (OVOS-INTENT-2 §4.3): a
+# demonstrative pronoun must never fill the color slot. Without this,
+# "set the color to that" binds {color}="that" and reports a bogus color.
+# Excluding the deictics leaves {color} unresolved so a later stage — an
+# OVOS-CONTEXT-1 §7 context fill or a re-prompt — can supply the color the
+# user meant.
+den
+det
+denne
+dette
+den der
+denne her
+dem
+disse

--- a/locale/da-DK/entities/color.entity
+++ b/locale/da-DK/entities/color.entity
@@ -1,0 +1,40 @@
+rød
+orange
+gul
+grøn
+blå
+lilla
+pink
+brun
+sort
+hvid
+grå
+grå
+cyan
+magenta
+petroleumsblå
+marineblå
+rødbrun
+oliven
+limegrøn
+indigo
+violet
+turkis
+guld
+sølv
+beige
+solbrun
+lavendel
+laks
+karmoisinrød
+koral
+khaki
+møbeltræ
+lys havgrøn
+murstensrød
+mørk skifergrå
+himmelblå
+skovgrøn
+knaldpink
+midnatsblå
+(lys|mørk|bleg|dyb|klar) (rød|orange|gul|grøn|blå|lilla|pink|brun|grå)

--- a/locale/da-DK/intents/request-color-by-hex.intent
+++ b/locale/da-DK/intents/request-color-by-hex.intent
@@ -1,1 +1,2 @@
 hvad (farve|farve) har en hex-kode på {hex_code}
+hvilken farve er [hex-koden] {hex_code}

--- a/locale/da-DK/intents/request-color-by-name.intent
+++ b/locale/da-DK/intents/request-color-by-name.intent
@@ -1,2 +1,4 @@
 Vis mig (farve|farve) {color}
 hvordan ser (farve|farve) {color} ud
+(sæt|skift) [farven] til {color}
+fortæl mig om [farven] {color}

--- a/locale/da-DK/intents/request-color-by-rgb.intent
+++ b/locale/da-DK/intents/request-color-by-rgb.intent
@@ -1,1 +1,2 @@
 hvilken farve har en RGB-værdi på {rgb}
+hvilken farve er [RGB-værdien] {rgb}


### PR DESCRIPTION
Adds the two files that were missing from the existing da-DK translation (present in every other locale): color.blacklist (demonstrative-pronoun exclusion list for the {color} slot) and entities/color.entity (the color-name entity list).

Also fills in 4 intent template lines that existed in en-US but were missing from da-DK (request-color-by-name.intent, request-color-by-rgb.intent, request-color-by-hex.intent), bringing da-DK to full parity with en-US.