### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # <img src="https://raw.githack.com/FortAwesome/Font-Awesome/master/svgs/solid/palette.svg" card_color="#22A7F0" width="50" height="50" style="vertical-align:bottom"/> Color Picker
-Look up colors by voice. Powered by [ovos-color-parser](https://github.com/OpenVoiceOS/ovos-color-parser)
+Look up colors by voice. The skill uses [ovos-color-parser](https://github.com/OpenVoiceOS/ovos-color-parser) to find the hex and RGB values for standard color names.
 
 ## About
-Find the hex and rgb values for any of the standard color names.
+Ask for a color by name. The skill returns the hex and RGB values for any standard color name.
 
 <p float="left">
   <img src="screenshots/screenshot-color-fire-brick.png" width="300" alt="Screenshot of Fire Brick request" />


### PR DESCRIPTION
Rewrites the README prose for clarity while keeping every fact, code block, and section unchanged in substance.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to link `ovos-color-parser`.
  * Clarified that the skill returns both hex and RGB values for standard color names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->