### PR TITLE
fix: revert stripped-key workaround now that ovos-spec-tools 1.6.3a1 fixes slot normalization

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -40,10 +40,10 @@ class ColorPickerSkill(OVOSSkill):
 
         Example: 'What color is _________'
         """
-        # padacioso strips underscores from slot names before returning
-        # match_data, so the {requested_color} template placeholder surfaces
-        # here as "requestedcolor", not "requested_color".
-        requested_color = message.data.get("requestedcolor")
+        # ovos-spec-tools>=1.6.3a1 fixes normalize_for_match() so it no
+        # longer mangles {slot} interiors; padacioso returns the
+        # spec-correct underscored key "requested_color".
+        requested_color = message.data.get("requested_color")
         if is_hex_code_valid(requested_color.replace(" ", "")):
             message = message.forward("", {"hex_code": requested_color.replace(" ", "")})
             self.handle_request_color_by_hex(message)
@@ -104,12 +104,11 @@ class ColorPickerSkill(OVOSSkill):
 
         Example: 'what color has a hex code of bada55'
         """
-        # padacioso strips underscores from slot names, so a direct
-        # request-color-by-hex.intent match surfaces "hexcode"; the
-        # internal forward() from handle_request_color still sets the
-        # underscored "hex_code" key explicitly -- accept both.
-        requested_hex_code = (message.data.get("hex_code")
-                               or message.data.get("hexcode") or "").replace(" ", "")
+        # ovos-spec-tools>=1.6.3a1 fixes normalize_for_match() so a direct
+        # request-color-by-hex.intent match surfaces the spec-correct
+        # underscored key "hex_code" (same key the internal forward() from
+        # handle_request_color already sets).
+        requested_hex_code = (message.data.get("hex_code") or "").replace(" ", "")
         self.log.info("Requested color: %s", requested_hex_code)
         if not is_hex_code_valid(requested_hex_code):
             self.speak_dialog("color-not-found")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ test = [
     "ovos-plugin-manager>=2.9.0a1,<3.0.0",
     "ovos-config>=2.1.4a5,<3.0.0",
     "ovos-utils>=0.13.4a1,<1.0.0",
-    "ovos-spec-tools>=1.4.0a1,<2.0.0"
+    "ovos-spec-tools>=1.6.3a1,<2.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Reverts the stripped-key workaround from #33 now that the underlying bug is fixed upstream.

**Context:** `ovos-spec-tools` 1.6.3a1 fixes `normalize_for_match()` mangling `{slot}` interiors, so padacioso returns `requested_color`/`hex_code` again instead of `requestedcolor`/`hexcode`. #33 made the handlers read the stripped keys as a workaround; this PR flips both back to the spec-correct underscored keys, with no dual-key fallback (deterministic given the floor pin below).

**Pin:** bumped the `test` extra's `ovos-spec-tools` floor from `>=1.4.0a1` to `>=1.6.3a1` in `pyproject.toml`. padacioso's own floor (`ovos-spec-tools>=1.4.0a1`, verified against its published METADATA) still admits the buggy version, so nothing else in the dependency graph enforces the fix -- same pattern as ovos-core#847's `closest_lang` contract pin.

**Verification (fresh clone, throwaway venv, `uv pip install --pre`):**
- `pip show ovos-spec-tools` resolved to `1.6.3a1` with the bumped pin.
- Golden e2e suite (`test/end2end/test_golden_utterances.py`, 15 rows incl. the two that previously crashed): green, `15 passed`.
- Red-check: forcing `ovos-spec-tools==1.6.2a1` and calling `handle_request_color` directly with the key `normalize_for_match()` actually produces at that version (`requestedcolor`) reproduces `AttributeError: 'NoneType' object has no attribute 'replace'`; forcing `1.6.3a1` and using the resulting key (`requested_color`) succeeds. This proves the pin is load-bearing.
- Note: the golden e2e suite itself only asserts on emitted bus-message types (intent classification), not on handler-internal exceptions, so the crash does not fail that particular suite either way -- the unit-level check above is what demonstrates the regression the pin guards against. Full suite stayed green in both directions.

**Claims verified:** the diff, the pin location/rationale, and the red/green evidence above were verified against this branch's actual source and by running the commands directly (not carried over from #33's report). #33's claim about padacioso's key-stripping behavior was re-confirmed independently via `ovos_spec_tools.normalize_for_match()`.
