### PR TITLE
fix: allow ovos-workshop 9.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 keywords = ["ovos", "skill", "plugin"]
 dependencies = [
-    "ovos-workshop>=8.0.0,<9.0.0",
+    "ovos-workshop>=8.0.0,<10.0.0",
     "ovos-color-parser"
 ]
 
@@ -24,7 +24,7 @@ test = [
     "pytest-timeout>=2.0.0",
     "ovos-core>=2.2.4a1,<2.3.0",
     "ovos-padatious>=1.8.0a1,<2.0.0",
-    "ovos-workshop>=8.3.0a1,<9.0.0",
+    "ovos-workshop>=8.3.0a1,<10.0.0",
     "ovos-bus-client>=2.2.0a1,<3.0.0",
     "ovos-plugin-manager>=2.9.0a1,<3.0.0",
     "ovos-config>=2.1.4a5,<3.0.0",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude (Opus 4.8 orchestrating, Sonnet 5 drafting this text) via Claude Code — NOT human-reviewed. Verify before acting.

This skill pinned `ovos-workshop>=0.0.15,<9.0.0`, but current ovos-core requires `ovos-workshop>=9.3.11a1,<10.0.0`. That stale cap means a normal install of this skill alongside latest ovos-core tries to downgrade ovos-workshop into the 8.x line, which breaks ovos-core's own requirement and leaves the environment unusable.

This skill was verified loading and serving live on ovos-workshop 9.3.13a1 on a real deployment, so the fix is just to widen the upper bound to `<10.0.0`. The lower floor is unchanged; this is a floor-preserving upper-cap bump only.
